### PR TITLE
Lint Migrations.sol

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,23 +1,24 @@
 pragma solidity ^0.4.2;
 
+
 contract Migrations {
-  address public owner;
-  uint public last_completed_migration;
+    address public owner;
+    uint public lastCompletedMigration;
 
-  modifier restricted() {
-    if (msg.sender == owner) _;
-  }
+    modifier restricted() {
+        if (msg.sender == owner) _;
+    }
 
-  function Migrations() {
-    owner = msg.sender;
-  }
+    function Migrations() public {
+        owner = msg.sender;
+    }
 
-  function setCompleted(uint completed) restricted {
-    last_completed_migration = completed;
-  }
+    function setCompleted(uint completed) public restricted {
+        lastCompletedMigration = completed;
+    }
 
-  function upgrade(address new_address) restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
+    function upgrade(address newAddress) public restricted {
+        Migrations upgraded = Migrations(newAddress);
+        upgraded.setCompleted(lastCompletedMigration);
+    }
 }


### PR DESCRIPTION
Addresses [truffle-migrate 19](https://github.com/trufflesuite/truffle-migrate/issues/19)

- [x] Compiles (Remix w/ solc 0.4.19).
- [x] Lints (used Solhint v 1.1.9, as suggested by the slack thread)

+ Solhint warns about not locking the pragma. However a best-practices issue [here](https://github.com/ConsenSys/smart-contract-best-practices/issues/125) arrived at the conclusion that libraries and platforms should not pin. 

+ Adds `public` modifier to everything including constructor. More on constructor visibility over at Solidity [here](https://github.com/ethereum/solidity/issues/3132)

Remix warns that:
>Gas requirement of function Migrations.upgrade(address) high: infinite. If the gas requirement of a function is higher than the block gas limit, it cannot be executed. Please avoid loops in your functions or actions that modify large areas of storage (this includes clearing or copying arrays in storage)

Probably fine for most people though :)
